### PR TITLE
[E084-MG < T0557-MG] Fix error handling in explicit transactional mode

### DIFF
--- a/src/connection-int.c
+++ b/src/connection-int.c
@@ -149,16 +149,20 @@ int connection_fetch(ConnectionObject *conn, PyObject **row, int *has_more) {
     // right behaviour and raise error at the right time. Cursor::fetchone has
     // the most questionable behaviour because it returns error one step
     // earlier.
+    connection_handle_error(conn, status);
     return -1;
   }
   if (status == 1 && row) {
     PyObject *pyresult = mg_list_to_py_tuple(mg_result_row(result));
     if (!pyresult) {
       connection_discard_all(conn);
+      // the connection_handle_error mustn't be called here, as the error
+      // doesn't affect the status of the connection
       return -1;
     }
     *row = pyresult;
   }
+  assert(status == 0 || status == 1);
   return status;
 }
 

--- a/src/connection.h
+++ b/src/connection.h
@@ -42,8 +42,6 @@ extern PyTypeObject ConnectionType;
 
 int connection_raise_if_bad_status(const ConnectionObject *conn);
 
-void connection_handle_error(ConnectionObject *conn, int error);
-
 int connection_run_without_results(ConnectionObject *conn, const char *query);
 
 int connection_run(ConnectionObject *conn, const char *query, PyObject *params,

--- a/src/connection.h
+++ b/src/connection.h
@@ -42,7 +42,7 @@ extern PyTypeObject ConnectionType;
 
 int connection_raise_if_bad_status(const ConnectionObject *conn);
 
-void connection_handle_error(ConnectionObject *conn);
+void connection_handle_error(ConnectionObject *conn, int error);
 
 int connection_run_without_results(ConnectionObject *conn, const char *query);
 

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -225,7 +225,7 @@ PyObject *cursor_execute(CursorObject *cursor, PyObject *args) {
     Py_DECREF(row);
   }
   if (status < 0) {
-    connection_handle_error(cursor->conn);
+    connection_handle_error(cursor->conn, status);
     goto cleanup;
   }
 
@@ -298,7 +298,7 @@ PyObject *cursor_fetchone(CursorObject *cursor, PyObject *args) {
       if (row) {
         Py_DECREF(row);
       }
-      connection_handle_error(cursor->conn);
+      connection_handle_error(cursor->conn, -1);
       cursor_reset(cursor);
       return NULL;
     } else if (fetch_status_first == 0) {
@@ -451,7 +451,7 @@ PyObject *cursor_fetchall(CursorObject *cursor, PyObject *args) {
       pull_status = connection_pull(cursor->conn, 0);
       if (pull_status != 0) {
         Py_DECREF(results);
-        connection_handle_error(cursor->conn);
+        connection_handle_error(cursor->conn, pull_status);
         cursor_reset(cursor);
         return NULL;
       }
@@ -473,7 +473,7 @@ PyObject *cursor_fetchall(CursorObject *cursor, PyObject *args) {
         }
       } else {
         Py_DECREF(results);
-        connection_handle_error(cursor->conn);
+        connection_handle_error(cursor->conn, fetch_status);
         cursor_reset(cursor);
         return NULL;
       }

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -292,8 +292,11 @@ PyObject *cursor_fetchone(CursorObject *cursor, PyObject *args) {
     int has_more_second = 0;
     int fetch_status_first =
         connection_fetch(cursor->conn, &row, &has_more_first);
-    int fetch_status_second =
+    int fetch_status_second = 0;
+    if (fetch_status_first == 1) {
+      fetch_status_second =
         connection_fetch(cursor->conn, NULL, &has_more_second);
+    }
     if (fetch_status_first == -1 || fetch_status_second == -1) {
       if (row) {
         Py_DECREF(row);

--- a/src/cursor.c
+++ b/src/cursor.c
@@ -225,7 +225,6 @@ PyObject *cursor_execute(CursorObject *cursor, PyObject *args) {
     Py_DECREF(row);
   }
   if (status < 0) {
-    connection_handle_error(cursor->conn, status);
     goto cleanup;
   }
 
@@ -295,13 +294,12 @@ PyObject *cursor_fetchone(CursorObject *cursor, PyObject *args) {
     int fetch_status_second = 0;
     if (fetch_status_first == 1) {
       fetch_status_second =
-        connection_fetch(cursor->conn, NULL, &has_more_second);
+          connection_fetch(cursor->conn, NULL, &has_more_second);
     }
     if (fetch_status_first == -1 || fetch_status_second == -1) {
       if (row) {
         Py_DECREF(row);
       }
-      connection_handle_error(cursor->conn, -1);
       cursor_reset(cursor);
       return NULL;
     } else if (fetch_status_first == 0) {
@@ -454,7 +452,6 @@ PyObject *cursor_fetchall(CursorObject *cursor, PyObject *args) {
       pull_status = connection_pull(cursor->conn, 0);
       if (pull_status != 0) {
         Py_DECREF(results);
-        connection_handle_error(cursor->conn, pull_status);
         cursor_reset(cursor);
         return NULL;
       }
@@ -476,7 +473,6 @@ PyObject *cursor_fetchall(CursorObject *cursor, PyObject *args) {
         }
       } else {
         Py_DECREF(results);
-        connection_handle_error(cursor->conn, fetch_status);
         cursor_reset(cursor);
         return NULL;
       }

--- a/test/test_cursor.py
+++ b/test/test_cursor.py
@@ -207,6 +207,23 @@ class TestCursorInRegularConnection:
 
         assert cursor.description is None
 
+    def test_cursor_fetchone_without_result(self, memgraph_server):
+        host, port = memgraph_server
+        conn = mgclient.connect(host=host, port=port)
+        cursor = conn.cursor()
+
+        cursor.execute('MATCH (n:NonExistingLabel) RETURN n')
+        result = cursor.fetchone()
+        assert result is None
+
+    def test_cursor_fetchmany_without_result(self, memgraph_server):
+        host, port = memgraph_server
+        conn = mgclient.connect(host=host, port=port)
+        cursor = conn.cursor()
+
+        cursor.execute('MATCH (n:NonExistingLabel) RETURN n')
+        assert cursor.fetchmany() == []
+
 
 class TestCursorInAsyncConnection:
     def test_cursor_close(self, memgraph_server):
@@ -406,3 +423,20 @@ class TestCursorInAsyncConnection:
             cursor.execute("jdfklfjkdalfja")
 
         assert cursor.description is None
+
+    def test_cursor_fetchone_without_result(self, memgraph_server):
+        host, port = memgraph_server
+        conn = mgclient.connect(host=host, port=port, lazy=True)
+        cursor = conn.cursor()
+
+        cursor.execute('MATCH (n:NonExistingLabel) RETURN n')
+        result = cursor.fetchone()
+        assert result is None
+
+    def test_cursor_fetchmany_without_result(self, memgraph_server):
+        host, port = memgraph_server
+        conn = mgclient.connect(host=host, port=port, lazy=True)
+        cursor = conn.cursor()
+
+        cursor.execute('MATCH (n:NonExistingLabel) RETURN n')
+        assert cursor.fetchmany() == []


### PR DESCRIPTION
This PR aims to fix the handling of the state of the connection when an error happens during query execution which doesn't move the session to MG_SESSION_BAD state, only resets it. When such error happens, then `connection_run` should start a new transaction before running the next query.