### PR TITLE
Update the docs with OpenSSL headers

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -92,6 +92,7 @@ build it from you will need:
 
   * CMake 3.8 or newer
   * OpenSSL 1.0.2 or newer
+  * OpenSSL 1.0.2 or newer header files
 
 Building on Linux
 *****************


### PR DESCRIPTION
The correct package is used in the example commands, but the development package is not mentioned in the requirements. This PR aims to fix that.