### PR TITLE
[master < MG-setup-py-improvements] Improve setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -158,9 +158,7 @@ class BuildMgclientExt(build_ext):
         return [f'-DOPENSSL_ROOT_DIR={openssl_root_dir}']
 
     def get_cflags(self):
-        cflags = os.getenv('CFLAGS')
-        all_warnings_as_error_flag ='-Werror=all'
-        return all_warnings_as_error_flag if cflags is None else f'{cflags} {all_warnings_as_error_flag}'
+        return "{0} -Werror=all".format(os.getenv('CFLAGS', '')).strip()
 
     def build_mgclient_for(self, extension: Extension):
         '''

--- a/setup.py
+++ b/setup.py
@@ -288,7 +288,8 @@ setup(name='pymgclient',
       ext_modules=[
           Extension(EXTENSION_NAME,
                     sources=sources,
-                    depends=headers)
+                    depends=headers,
+                    extra_compile_args=["-Werror=all", "-std=c99"])
       ],
       project_urls={
           'Source': 'https://github.com/memgraph/pymgclient',

--- a/setup.py
+++ b/setup.py
@@ -157,6 +157,11 @@ class BuildMgclientExt(build_ext):
             f'Found OpenSSL in {openssl_root_dir}', level=log.INFO)
         return [f'-DOPENSSL_ROOT_DIR={openssl_root_dir}']
 
+    def get_cflags(self):
+        cflags = os.getenv('CFLAGS')
+        all_warnings_as_error_flag ='-Werror=all'
+        return all_warnings_as_error_flag if cflags is None else f'{cflags} {all_warnings_as_error_flag}'
+
     def build_mgclient_for(self, extension: Extension):
         '''
         Builds mgclient library and configures the extension to be able to use
@@ -204,7 +209,8 @@ class BuildMgclientExt(build_ext):
             f'-DCMAKE_BUILD_TYPE={build_type}',
             f'-DCMAKE_INSTALL_PREFIX={mgclient_install_path}',
             '-DBUILD_TESTING=OFF',
-            '-DCMAKE_POSITION_INDEPENDENT_CODE=ON'
+            '-DCMAKE_POSITION_INDEPENDENT_CODE=ON',
+            f'-DCMAKE_C_FLAGS="{self.get_cflags()}"'
         ]
         cmake_config_command.extend(self.get_extra_cmake_config_args())
         generator = self.get_cmake_generator()


### PR DESCRIPTION
Long story short, both GCC and clang allow you to use an undeclared function and they only produce a warning message (even though C99 makes this an error, compilers don't care). Linking a shared library with an undefined symbol is "[just fine](https://stackoverflow.com/a/44171576/6639989)". In C++ we got an error if we want to use an undeclared function, but not in C with GCC and clang, that's why the `-Werror=all` flag is introduced to prevent this and probably similar bugs.