### PR TITLE
Enable running CI on manual trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+
 
 jobs:
   build_and_test_ubuntu:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   push:
   workflow_dispatch:
+  schedule:
+    - cron: "0 1 * * *"
 
 
 jobs:


### PR DESCRIPTION
It would be nice to run the CI manually, e.g. when we open a PR after a long time, it would be nice to now whether the CI is broken or the changes we did.