### PR TITLE
Add the possibility to connect to a specific database

### DIFF
--- a/src/connection-int.c
+++ b/src/connection-int.c
@@ -36,7 +36,7 @@ void connection_handle_error(ConnectionObject *conn) {
 }
 
 int connection_run_without_results(ConnectionObject *conn, const char *query) {
-  int status = mg_session_run(conn->session, query, NULL, NULL, NULL, NULL);
+  int status = mg_session_run(conn->session, query, NULL, conn->extras, NULL, NULL);
   if (status != 0) {
     connection_handle_error(conn);
     return -1;
@@ -87,7 +87,7 @@ int connection_run(ConnectionObject *conn, const char *query, PyObject *params,
 
   const mg_list *mg_columns;
   int status =
-      mg_session_run(conn->session, query, mg_params, NULL, &mg_columns, NULL);
+      mg_session_run(conn->session, query, mg_params, conn->extras, &mg_columns, NULL);
   mg_map_destroy(mg_params);
 
   if (status != 0) {

--- a/src/connection.h
+++ b/src/connection.h
@@ -35,6 +35,7 @@ typedef struct ConnectionObject {
   int status;
   int autocommit;
   int lazy;
+  mg_map *extras;
 } ConnectionObject;
 // clang-format on
 

--- a/src/mgclientmodule.c
+++ b/src/mgclientmodule.c
@@ -197,7 +197,7 @@ static PyObject *mgclient_connect(PyObject *self, PyObject *args,
 PyDoc_STRVAR(mgclient_connect_doc,
 "connect(host=None, address=None, port=None, username=None, password=None,\n\
          client_name=None, sslmode=mgclient.MG_SSLMODE_DISABLE,\n\
-         sslcert=None, sslkey=None, trust_callback=None, lazy=False)\n\
+         sslcert=None, sslkey=None, trust_callback=None, lazy=False, database=None)\n\
 --\n\
 \n\
 Makes a new connection to the database server and returns a\n\
@@ -271,7 +271,11 @@ Currently recognized parameters are:\n\
 \n\
    * :obj:`lazy`\n\
 \n\
-        If this is set to ``True``, a lazy connection is made. Default is ``False``.");
+        If this is set to ``True``, a lazy connection is made. Default is ``False``.\n\
+\n\
+   * :obj:`database`\n\
+\n\
+        If set, all queries executed will target the defined database. Default is ``None``.");
 // clang-format on
 
 static PyMethodDef mgclient_methods[] = {


### PR DESCRIPTION
Add multi-tenant capability.
```
conn = mgclient.connect(address...., database="db")
```
will return a connection that is limited to the defined database.