### PR TITLE
Add support for auth with custom schemes

### DIFF
--- a/src/connection.c
+++ b/src/connection.c
@@ -39,10 +39,10 @@ static int execute_trust_callback(const char *hostname, const char *ip_address,
 
 static int connection_init(ConnectionObject *conn, PyObject *args,
                            PyObject *kwargs) {
-  static char *kwlist[] = {
-      "host",     "address",        "port",        "scheme",  "username",
-      "password", "credentials",    "client_name", "sslmode", "sslcert",
-      "sslkey",   "trust_callback", "lazy",        NULL};
+  static char *kwlist[] = {"host",     "address",  "port",           "scheme",
+                           "username", "password", "client_name",    "sslmode",
+                           "sslcert",  "sslkey",   "trust_callback", "lazy",
+                           NULL};
 
   const char *host = NULL;
   const char *address = NULL;
@@ -50,7 +50,6 @@ static int connection_init(ConnectionObject *conn, PyObject *args,
   const char *scheme = NULL;
   const char *username = NULL;
   const char *password = NULL;
-  const char *credentials = NULL;
   const char *client_name = NULL;
   int sslmode_int = MG_SSLMODE_DISABLE;
   const char *sslcert = NULL;
@@ -59,8 +58,8 @@ static int connection_init(ConnectionObject *conn, PyObject *args,
   int lazy = 0;
 
   if (!PyArg_ParseTupleAndKeywords(
-          args, kwargs, "|$ssisssssissOp", kwlist, &host, &address, &port,
-          &scheme, &username, &password, &credentials, &client_name,
+          args, kwargs, "|$ssissssissOp", kwlist, &host, &address, &port,
+          &scheme, &username, &password, &client_name,
           &sslmode_int, &sslcert, &sslkey, &trust_callback, &lazy)) {
     return -1;
   }
@@ -99,7 +98,6 @@ static int connection_init(ConnectionObject *conn, PyObject *args,
   mg_session_params_set_scheme(params, scheme);
   mg_session_params_set_username(params, username);
   mg_session_params_set_password(params, password);
-  mg_session_params_set_credentials(params, credentials);
   if (client_name) {
     mg_session_params_set_user_agent(params, client_name);
   }

--- a/src/connection.c
+++ b/src/connection.c
@@ -39,15 +39,18 @@ static int execute_trust_callback(const char *hostname, const char *ip_address,
 
 static int connection_init(ConnectionObject *conn, PyObject *args,
                            PyObject *kwargs) {
-  static char *kwlist[] = {"host",     "address",        "port",    "username",
-                           "password", "client_name",    "sslmode", "sslcert",
-                           "sslkey",   "trust_callback", "lazy",    NULL};
+  static char *kwlist[] = {
+      "host",     "address",        "port",        "scheme",  "username",
+      "password", "credentials",    "client_name", "sslmode", "sslcert",
+      "sslkey",   "trust_callback", "lazy",        NULL};
 
   const char *host = NULL;
   const char *address = NULL;
   int port = -1;
+  const char *scheme = NULL;
   const char *username = NULL;
   const char *password = NULL;
+  const char *credentials = NULL;
   const char *client_name = NULL;
   int sslmode_int = MG_SSLMODE_DISABLE;
   const char *sslcert = NULL;
@@ -55,10 +58,10 @@ static int connection_init(ConnectionObject *conn, PyObject *args,
   PyObject *trust_callback = NULL;
   int lazy = 0;
 
-  if (!PyArg_ParseTupleAndKeywords(args, kwargs, "|$ssisssissOp", kwlist, &host,
-                                   &address, &port, &username, &password,
-                                   &client_name, &sslmode_int, &sslcert,
-                                   &sslkey, &trust_callback, &lazy)) {
+  if (!PyArg_ParseTupleAndKeywords(
+          args, kwargs, "|$ssisssssissOp", kwlist, &host, &address, &port,
+          &scheme, &username, &password, &credentials, &client_name,
+          &sslmode_int, &sslcert, &sslkey, &trust_callback, &lazy)) {
     return -1;
   }
 
@@ -93,8 +96,10 @@ static int connection_init(ConnectionObject *conn, PyObject *args,
   mg_session_params_set_host(params, host);
   mg_session_params_set_port(params, (uint16_t)port);
   mg_session_params_set_address(params, address);
+  mg_session_params_set_scheme(params, scheme);
   mg_session_params_set_username(params, username);
   mg_session_params_set_password(params, password);
+  mg_session_params_set_credentials(params, credentials);
   if (client_name) {
     mg_session_params_set_user_agent(params, client_name);
   }

--- a/test/auth_module/dummy_auth_module.py
+++ b/test/auth_module/dummy_auth_module.py
@@ -1,0 +1,21 @@
+#!/usr/bin/python3
+import io
+import json
+
+
+def authenticate(scheme: str, response: str):
+    return {
+        "authenticated": True,
+        "role": "architect",
+        "username": "andy",
+    }
+
+
+if __name__ == "__main__":
+    # I/O with Memgraph
+    input_stream = io.FileIO(1000, mode="r")
+    output_stream = io.FileIO(1001, mode="w")
+    while True:
+        params = json.loads(input_stream.readline().decode("ascii"))
+        ret = authenticate(**params)
+        output_stream.write((json.dumps(ret) + "\n").encode("ascii"))

--- a/test/common.py
+++ b/test/common.py
@@ -70,7 +70,7 @@ class Memgraph:
             self.process.wait()
 
 
-def start_memgraph(cert_file="", key_file=""):
+def start_memgraph(cert_file="", key_file="", auth_module_mappings=""):
     if MEMGRAPH_HOST:
         use_ssl = MEMGRAPH_STARTED_WITH_SSL is not None
         return Memgraph(MEMGRAPH_HOST, MEMGRAPH_PORT, use_ssl, None)
@@ -94,6 +94,8 @@ def start_memgraph(cert_file="", key_file=""):
         "--log-file",
         "",
     ]
+    if auth_module_mappings:
+        cmd.insert(-2, f"--auth-module-mappings={auth_module_mappings}")
     memgraph_process = subprocess.Popen(cmd)
     wait_for_server(MEMGRAPH_PORT)
     use_ssl = True if key_file.strip() else False


### PR DESCRIPTION
This PR adds the `scheme` parameter to the `connect` function. 
Memgraph’s SSO capabilities use custom values of `scheme`, making this PR necessary for SSO via Python client.

Depends on https://github.com/memgraph/mgclient/pull/62