### PR TITLE
Added fail-safe to docs build

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -41,15 +41,35 @@ jobs:
           echo "PYTHON_VERSION=$version" >> $GITHUB_ENV
 
       - name: Download Python Artifact
+        id: download
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: pymgclient-linux-${{ env.PYTHON_VERSION }}
           path: ./dist
 
+      - name: Record download status
+        if: always()
+        id: record
+        run: |
+          echo "Download step outcome: ${{ steps.download.outcome }}"
+          if [[ "${{ steps.download.outcome }}" == "success" ]]; then
+            echo "DOWNLOAD_STATUS=success" >> $GITHUB_OUTPUT
+          else
+            echo "DOWNLOAD_STATUS=failure" >> $GITHUB_OUTPUT
+          fi
+
       - name: Install Pymgclient
+        if: steps.record.outputs.DOWNLOAD_STATUS == 'success'
         run: |
           source env/bin/activate
           pip install dist/*.whl
+
+      - name: Install Pymgclient
+        if: steps.record.outputs.DOWNLOAD_STATUS == 'failure'
+        run: |
+          source env/bin/activate
+          pip install pymgclient
 
       - name: Build docs
         run: |

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -59,13 +59,13 @@ jobs:
             echo "DOWNLOAD_STATUS=failure" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install Pymgclient
+      - name: Install Pymgclient (Artifact)
         if: steps.record.outputs.DOWNLOAD_STATUS == 'success'
         run: |
           source env/bin/activate
           pip install dist/*.whl
 
-      - name: Install Pymgclient
+      - name: Install Pymgclient (PyPI)
         if: steps.record.outputs.DOWNLOAD_STATUS == 'failure'
         run: |
           source env/bin/activate


### PR DESCRIPTION
Added step to download package form pip if the job fails to find the correct artifact created in the current workflow. This means that the docs can be rebuilt independent of the release workflow if needed.
Fixes: #72 