### PR TITLE
Stop using macos-12 runner

### DIFF
--- a/.github/workflows/reusable_buildtest.yml
+++ b/.github/workflows/reusable_buildtest.yml
@@ -374,11 +374,6 @@ jobs:
           - '3.11'
           - '3.12'
           - '3.13'
-        include:
-          - {platform: [macos-12, ARM64, self-hosted], python_version: '3.10'}
-          - {platform: [macos-12, ARM64, self-hosted], python_version: '3.11'}
-          - {platform: [macos-12, ARM64, self-hosted], python_version: '3.12'}
-          - {platform: [macos-12, ARM64, self-hosted], python_version: '3.13'}
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The `strange` runner removes itself after some time, it also runs an older version of macOS, so let's remove it for now.