### PR TITLE
Replace `PyDateTime_DATE_GET_TZINFO` macro with shim

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,18 @@ Changelog
 =========
 
 ######
+1.5.1
+######
+
+
+*********
+Bug Fixes
+*********
+
+  * Replace `PyDateTime_DATE_GET_TZINFO` with Python 3.9 compatible function
+
+
+######
 1.5.0
 ######
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ parser.read("setup.cfg")
 
 static_openssl = parser.getboolean("build_ext", "static_openssl", fallback=False)
 
-version = os.getenv("PYMGCLIENT_OVERRIDE_VERSION", "1.5.0")
+version = os.getenv("PYMGCLIENT_OVERRIDE_VERSION", "1.5.1")
 
 
 def list_all_files_in_dir(path):


### PR DESCRIPTION
`PyDateTime_DATE_GET_TZINFO` requires Python 3.10, and for the time being we are still supporting Python 3.9. This replaces the macro with the exact underlying code in order to keep legacy support.