### PR TITLE
bump default version of pymgclient used during build

### DIFF
--- a/tools/pymgclient_build_meta.py
+++ b/tools/pymgclient_build_meta.py
@@ -1,4 +1,4 @@
 # pymgclient_build_meta.py
 import os
 
-__version__ = os.getenv("PYMGCLIENT_OVERRIDE_VERSION", "1.5.2")
+__version__ = os.getenv("PYMGCLIENT_OVERRIDE_VERSION", "1.6.0")


### PR DESCRIPTION
Update `tools/pymgclient_build_meta.py` with a new default version.